### PR TITLE
ISSUE-56: Used npm ci command to install the packages with predefined versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 service:
   - redis-server
 script:
-  - npm install
+  - npm ci
   - npm run test
 after_success:
   - npm run coverage


### PR DESCRIPTION
- Fixes, for installing packages during travis-build should be done from `package-lock.json`, has been added